### PR TITLE
Make CodeCarbon run offline

### DIFF
--- a/.codecarbon.config
+++ b/.codecarbon.config
@@ -1,4 +1,4 @@
 [codecarbon]
 log_level = DEBUG
-save_to_api = True
+save_to_api = False
 experiment_id = d960f128-b0b6-4eb2-a1e1-d2bbc81bbbe0


### PR DESCRIPTION
When running through the Notebooks, CodeCarbon produces several warnings about not being able to access and push to the CodeCarbon API. This PR silences these warnings by setting `save_to_api = False`. I am not sure if any aspect of this project relies on API access, so will leave it to @jianlianggao to merge if OK.